### PR TITLE
Sort entries by key & better output messages

### DIFF
--- a/localization_flow/jtlocalize/core/add_genstrings_comments_to_file.py
+++ b/localization_flow/jtlocalize/core/add_genstrings_comments_to_file.py
@@ -34,7 +34,7 @@ def add_genstrings_comments_to_file(localization_file, genstrings_err):
     errors_to_log = [line for line in genstrings_err.splitlines() if "used with multiple comments" not in line]
 
     if len(errors_to_log) > 0:
-        logging.warning("genstrings warnings:\n%s", "\n".join(errors_to_log))
+        logging.warning("------ genstrings errors: ------\n%s\n", "\n".join(errors_to_log))
 
     loc_file = open_strings_file(localization_file, "a")
 

--- a/localization_flow/jtlocalize/core/create_localized_strings_from_ib_files.py
+++ b/localization_flow/jtlocalize/core/create_localized_strings_from_ib_files.py
@@ -18,13 +18,11 @@ def write_string_pairs_from_ib_file_to_file(ib_files_directory, exclude_dirs, ou
 
     string_pairs = extract_string_pairs_in_dir(ib_files_directory, exclude_dirs, special_ui_components_prefix)
     output_file_desc = open_strings_file(output_file, "a")
-    write_section_header_to_file(output_file_desc, 'IB Files Section')
+
     for entry_key, entry_comment in string_pairs:
         output_file_desc.write('\n')
         if entry_key is not None:
             write_entry_to_file(output_file_desc, entry_comment, entry_key)
-        else:
-            write_section_header_to_file(output_file_desc, entry_comment)
 
     output_file_desc.close()
 

--- a/localization_flow/jtlocalize/core/handle_duplicates_in_localization.py
+++ b/localization_flow/jtlocalize/core/handle_duplicates_in_localization.py
@@ -29,11 +29,11 @@ def handle_duplications(file_path):
     """
     logging.info('Handling duplications for "%s"', file_path)
     f = open_strings_file(file_path, "r+")
-    header_comment_key_value_tuples = extract_header_comment_key_value_tuples_from_file(f)
+    comment_key_value_tuples = extract_comment_key_value_tuples_from_file(f)
     file_elements = []
     keys_to_objects = {}
     duplicates_found = []
-    for header_comment, comments, key, value in header_comment_key_value_tuples:
+    for comments, key, value in comment_key_value_tuples:
         if key in keys_to_objects:
             keys_to_objects[key].add_comments(comments)
             duplicates_found.append(key)
@@ -42,7 +42,7 @@ def handle_duplications(file_path):
             keys_to_objects[key] = loc_obj
             file_elements.append(loc_obj)
 
-    # Adding last section
+    # Sort by key
     file_elements = sorted(file_elements, key=lambda x: x.key)
 
     f.seek(0)

--- a/localization_flow/jtlocalize/core/handle_duplicates_in_localization.py
+++ b/localization_flow/jtlocalize/core/handle_duplicates_in_localization.py
@@ -31,28 +31,19 @@ def handle_duplications(file_path):
     f = open_strings_file(file_path, "r+")
     header_comment_key_value_tuples = extract_header_comment_key_value_tuples_from_file(f)
     file_elements = []
-    section_file_elements = []
     keys_to_objects = {}
     duplicates_found = []
     for header_comment, comments, key, value in header_comment_key_value_tuples:
-        if len(header_comment) > 0:
-            # New section - Appending the last section entries, sorted by comment
-            for elem in sorted(section_file_elements, key=lambda x: x.comments[0]):
-                file_elements.append(elem)
-            section_file_elements = []
-            file_elements.append(Comment(header_comment))
-
         if key in keys_to_objects:
             keys_to_objects[key].add_comments(comments)
             duplicates_found.append(key)
         else:
             loc_obj = LocalizationEntry(comments, key, value)
             keys_to_objects[key] = loc_obj
-            section_file_elements.append(loc_obj)
+            file_elements.append(loc_obj)
 
     # Adding last section
-    for elem in sorted(section_file_elements, key=lambda x: x.comments[0]):
-        file_elements.append(elem)
+    file_elements = sorted(file_elements, key=lambda x: x.key)
 
     f.seek(0)
 

--- a/localization_flow/jtlocalize/core/localization_diff.py
+++ b/localization_flow/jtlocalize/core/localization_diff.py
@@ -63,7 +63,7 @@ def localization_diff(localizable_file, translated_file, excluded_strings_file, 
  */
 """ % (VALUE_PLACEHOLDER,)))
 
-    for _header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+    for comments, key, value in extract_comment_key_value_tuples_from_file(f):
         if key in translated_list or key in excluded_file_dictionary:
             if key in old_translated_file_dictionary:
                 old_translated_file_dictionary.pop(key)

--- a/localization_flow/jtlocalize/core/localization_merge_back.py
+++ b/localization_flow/jtlocalize/core/localization_merge_back.py
@@ -42,10 +42,8 @@ def localization_merge_back(updated_localizable_file, old_translated_file, new_t
 
     f = open_strings_file(updated_localizable_file, "r")
 
-    for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+    for comments, key, value in extract_comment_key_value_tuples_from_file(f):
         translation_value = None
-        if len(header_comment) > 0:
-            output_file_elements.append(Comment(header_comment))
 
         if value in new_translated_file_dict:
             translation_value = new_translated_file_dict[value].value

--- a/localization_flow/jtlocalize/core/localization_utils.py
+++ b/localization_flow/jtlocalize/core/localization_utils.py
@@ -232,7 +232,7 @@ def append_dictionary_to_file(localization_key_to_comment, file_path, section_na
     """
     output_file = open_strings_file(file_path, "a")
     write_section_header_to_file(output_file, section_name)
-    for entry_key, entry_comment in sorted(localization_key_to_comment.iteritems(), key=operator.itemgetter(1)):
+    for entry_key, entry_comment in sorted(localization_key_to_comment.iteritems(), key=operator.itemgetter(0)):
         output_file.write(u'\n')
         write_entry_to_file(output_file, entry_comment, entry_key)
     output_file.close()
@@ -247,7 +247,7 @@ def write_dict_to_new_file(file_name, localization_key_to_comment):
 
     """
     output_file_descriptor = open_strings_file(file_name, "w")
-    for entry_key, entry_comment in sorted(localization_key_to_comment.iteritems(), key=operator.itemgetter(1)):
+    for entry_key, entry_comment in sorted(localization_key_to_comment.iteritems(), key=operator.itemgetter(0)):
         write_entry_to_file(output_file_descriptor, entry_comment, entry_key)
         output_file_descriptor.write(u'\n')
     output_file_descriptor.close()

--- a/localization_flow/jtlocalize/core/localization_utils.py
+++ b/localization_flow/jtlocalize/core/localization_utils.py
@@ -12,7 +12,7 @@ from localization_objects import *
 JTL_REGEX = r"""JTL\(\\?['"](.+?)\\?['"],\s*\\?['"](.+?)\\?['"]\)"""
 
 # Regexp to parse and inspect localization entries in the strings file.
-HEADER_COMMENT_KEY_VALUE_TUPLES_REGEX = '((/\*\*\* *[^\n]*? *\*\*\*/\n*)*)(/\* *[^;]* *\*/\n*)"(.*?)" *= *"(.*?)";\s*\n'
+COMMENT_KEY_VALUE_TUPLES_REGEX = '(/\* *[^;]* *\*/\n*)"(.*?)" *= *"(.*?)";\s*\n'
 
 
 def rewrite_localization_file_with_entry_modifications(localizable_file, output_file, modification_func):
@@ -20,10 +20,7 @@ def rewrite_localization_file_with_entry_modifications(localizable_file, output_
 
     output_file_elements = []
 
-    for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(file_descriptor):
-
-        if len(header_comment) > 0:
-            output_file_elements.append(Comment(header_comment))
+    for comments, key, value in extract_comment_key_value_tuples_from_file(file_descriptor):
 
         after_modification = modification_func(LocalizationEntry(comments, key, value))
 
@@ -92,12 +89,12 @@ def __generate_localization_dictionary_from_file(file_path, localization_entry_a
     """
     localization_dictionary = {}
     f = open_strings_file(file_path, "r+")
-    header_comment_key_value_tuples = extract_header_comment_key_value_tuples_from_file(f)
+    comment_key_value_tuples = extract_comment_key_value_tuples_from_file(f)
 
-    if len(header_comment_key_value_tuples) == 0:
+    if len(comment_key_value_tuples) == 0:
         logging.warning("Couldn't find any strings in file '%s'. Check encoding and format." % file_path)
 
-    for header_comment, comments, key, value in header_comment_key_value_tuples:
+    for comments, key, value in comment_key_value_tuples:
         localization_entry = LocalizationEntry(comments, key, value)
         localization_dictionary[
             localization_entry.__getattribute__(localization_entry_attribute_name_for_key)] = localization_entry
@@ -129,7 +126,7 @@ def generate_localization_value_to_entry_dictionary_from_file(file_path):
     return __generate_localization_dictionary_from_file(file_path, "value")
 
 
-def extract_header_comment_key_value_tuples_from_file(file_descriptor):
+def extract_comment_key_value_tuples_from_file(file_descriptor):
     """ Extracts tuples representing comments and localization entries from strings file.
 
     Args:
@@ -140,14 +137,14 @@ def extract_header_comment_key_value_tuples_from_file(file_descriptor):
 
     """
     file_data = file_descriptor.read()
-    findall_result = re.findall(HEADER_COMMENT_KEY_VALUE_TUPLES_REGEX, file_data, re.MULTILINE | re.DOTALL)
+    findall_result = re.findall(COMMENT_KEY_VALUE_TUPLES_REGEX, file_data, re.MULTILINE | re.DOTALL)
 
     returned_list = []
-    for header_comment, _ignored, raw_comments, key, value in findall_result:
+    for raw_comments, key, value in findall_result:
         comments = re.findall("/\* (.*?) \*/", raw_comments)
         if len(comments) == 0:
             comments = [u""]
-        returned_list.append((header_comment, comments, key, value))
+        returned_list.append((comments, key, value))
 
     return returned_list
 
@@ -211,16 +208,6 @@ def write_entry_to_file(file_descriptor, entry_comment, entry_key):
     file_descriptor.write(u'"%s" = "%s";\n' % (escaped_key, escaped_key))
 
 
-def write_section_header_to_file(file_descriptor, section_name):
-    """ Writes a section header to the file
-
-    Args:
-        file_descriptor (file, instance): The file to writes the section header to.
-        section_name (str): The name of the section.
-    """
-    file_descriptor.write('/*** %s ***/\n' % section_name)
-
-
 def append_dictionary_to_file(localization_key_to_comment, file_path, section_name):
     """ Appends dictionary of localization keys and comments to a file
 
@@ -231,7 +218,6 @@ def append_dictionary_to_file(localization_key_to_comment, file_path, section_na
 
     """
     output_file = open_strings_file(file_path, "a")
-    write_section_header_to_file(output_file, section_name)
     for entry_key, entry_comment in sorted(localization_key_to_comment.iteritems(), key=operator.itemgetter(0)):
         output_file.write(u'\n')
         write_entry_to_file(output_file, entry_comment, entry_key)

--- a/localization_flow/jtlocalize/core/localization_utils.py
+++ b/localization_flow/jtlocalize/core/localization_utils.py
@@ -69,7 +69,7 @@ def setup_logging(args=None):
     logging_level = logging.WARNING
     if args is not None and args.verbose:
         logging_level = logging.INFO
-    config = {"level": logging_level, "format": "jtlocalize:%(message)s"}
+    config = {"level": logging_level, "format": "jtlocalize: %(message)s"}
 
     if args is not None and args.log_path != "":
         config["filename"] = args.log_path

--- a/localization_flow/jtlocalize/core/merge_strings_files.py
+++ b/localization_flow/jtlocalize/core/merge_strings_files.py
@@ -34,10 +34,7 @@ def merge_strings_files(old_strings_file, new_strings_file):
 
     f = open_strings_file(new_strings_file, "r+")
 
-    for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
-        if len(header_comment) > 0:
-            output_file_elements.append(Comment(header_comment))
-
+    for comments, key, value in extract_comment_key_value_tuples_from_file(f):
         localize_value = value
         if key in old_localizable_dict:
             localize_value = old_localizable_dict[key].value

--- a/localization_flow/jtlocalize/genstrings.py
+++ b/localization_flow/jtlocalize/genstrings.py
@@ -92,7 +92,7 @@ def generate_strings(project_base_dir, localization_bundle_path, tmp_directory, 
 
     genstrings_rc = genstrings_process.returncode
     if genstrings_rc != 0:
-        logging.fatal("genstrings returned %d, aborting run!", genstrings_rc)
+        logging.fatal("\n!!!!!!!!! genstrings returned %d, ABORTING RUN !!!!!!!!!\n", genstrings_rc)
         sys.exit(genstrings_rc)
 
     create_localized_strings_from_ib_files(project_base_dir, exclude_dirs, tmp_localization_file)

--- a/localization_flow/jtlocalize/genstrings.py
+++ b/localization_flow/jtlocalize/genstrings.py
@@ -35,11 +35,6 @@ class GenerateStringsFileOperation(LocalizationCommandLineOperation):
         parser.add_argument("--tmp_directory", default=DEFAULT_TMP_DIRECTORY,
                             help="The default temporary directory to write files to in the process")
 
-        parser.add_argument("--special_ui_components_prefix",
-                            help="By default script will warn about ui components using JTL comments that aren't using "
-                                 "the JT prefix (e.g. JTLabel). if you pass a value like XYZ here, it won't warn about "
-                                 "components like XYZButton, XYZLabel, etc.")
-
         parser.add_argument("--exclude_dirs", nargs='+',
                             help="Directories to exclude when looking for source files to extract strings from")
 
@@ -53,16 +48,14 @@ class GenerateStringsFileOperation(LocalizationCommandLineOperation):
                          parsed_args.localization_bundle_path,
                          parsed_args.tmp_directory,
                          parsed_args.exclude_dirs,
-                         parsed_args.include_strings_from_file,
-                         parsed_args.special_ui_components_prefix)
+                         parsed_args.include_strings_from_file)
 
 
 def extract_source_files(base_dir, exclude_dirs):
     return find_files(base_dir, [".m", ".mm", ".swift"], exclude_dirs)
 
 
-def generate_strings(project_base_dir, localization_bundle_path, tmp_directory, exclude_dirs, include_strings_file,
-                     special_ui_components_prefix):
+def generate_strings(project_base_dir, localization_bundle_path, tmp_directory, exclude_dirs, include_strings_file):
     """
     Calls the builtin 'genstrings' command with JTLocalizedString as the string to search for,
     and adds strings extracted from UI elements internationalized with 'JTL' + removes duplications.
@@ -102,8 +95,7 @@ def generate_strings(project_base_dir, localization_bundle_path, tmp_directory, 
         logging.fatal("genstrings returned %d, aborting run!", genstrings_rc)
         sys.exit(genstrings_rc)
 
-    create_localized_strings_from_ib_files(project_base_dir, exclude_dirs, tmp_localization_file,
-                                           special_ui_components_prefix)
+    create_localized_strings_from_ib_files(project_base_dir, exclude_dirs, tmp_localization_file)
 
     if include_strings_file:
         target = open_strings_file(tmp_localization_file, "a")

--- a/localization_flow/jtlocalize/mock_translate.py
+++ b/localization_flow/jtlocalize/mock_translate.py
@@ -36,7 +36,7 @@ class WrapReplacement(Replacement):
 def replace_english_values(filename, replacement):
     f = open_strings_file(filename, "r+")
     localization_entries = []
-    for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+    for comments, key, value in extract_comment_key_value_tuples_from_file(f):
         localization_entries.append(LocalizationEntry(comments, key, replacement.replace_value(key)))
     f.close()
 

--- a/localization_flow/jtlocalize/tests/localization_diff_test.py
+++ b/localization_flow/jtlocalize/tests/localization_diff_test.py
@@ -33,7 +33,7 @@ class LocalizationDiffTest(unittest.TestCase):
 
         f = open_strings_file(NEW_TRANSLATED_FILE_PATH, "r")
 
-        for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+        for comments, key, value in extract_comment_key_value_tuples_from_file(f):
             localizable_key = localizable_values_to_objects[key]
             self.assertFalse(localizable_key in old_translated_file_keys_to_objects)
 
@@ -42,7 +42,7 @@ class LocalizationDiffTest(unittest.TestCase):
 
         f = open_strings_file(NEW_LOCALIZABLE_FILE_PATH, "r")
 
-        for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+        for comments, key, value in extract_comment_key_value_tuples_from_file(f):
             merged_value = merged_file_dict[key].value
             self.assertEqual(merged_value, "test(%s)" % value)
 

--- a/localization_flow/jtlocalize/tests/merge_strings_files_test.py
+++ b/localization_flow/jtlocalize/tests/merge_strings_files_test.py
@@ -32,7 +32,7 @@ class MergeLocalizableTest(unittest.TestCase):
 
         f = open_strings_file(MERGED_FILE_PATH, "r")
 
-        for header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+        for comments, key, value in extract_comment_key_value_tuples_from_file(f):
             if key in old_localizable_file_keys_to_objects:
                 self.assertEqual(value, old_localizable_file_keys_to_objects[key].value)
                 if key in new_localizable_file_keys_to_objects:

--- a/localization_flow/jtlocalize/word_count.py
+++ b/localization_flow/jtlocalize/word_count.py
@@ -1,5 +1,5 @@
 import argparse
-from core.localization_utils import extract_header_comment_key_value_tuples_from_file, open_strings_file
+from core.localization_utils import extract_comment_key_value_tuples_from_file, open_strings_file
 from jtlocalize.core.localization_commandline_operation import LocalizationCommandLineOperation
 
 __author__ = 'lwager'
@@ -25,7 +25,7 @@ def word_count(f_name):
     f = open_strings_file(f_name, "r")
 
     count = 0
-    for _header_comment, comments, key, value in extract_header_comment_key_value_tuples_from_file(f):
+    for comments, key, value in extract_comment_key_value_tuples_from_file(f):
         count += len(key.split())
     return count
 


### PR DESCRIPTION
This PR includes:
1. sort by key and not comment
2. remove "x is internationalized but isn't one of [JTLabel, ...]" warnings
3. nicer logging
4. some cleanups

Below is an example of the output when running scripts/genstrings.sh from SimplyPiano:
```
===== Fetching strings from content and configuration =====

===== Updating asla server repo =====
REPO_NAME: asla_server, BRANCH_NAME: master

Already up to date.
Current branch master is up to date.
Fetching strings from asla server code

===== Appending manually retained strings =====

===== Appending android strings =====
REPO_NAME: SimplyPianoDroid, BRANCH_NAME: better-translations

Current branch better-translations is up to date.
generating layout strings
generating content overrides strings
generating java source code strings
jtlocalize: ------ genstrings warnings: ------
genstrings: error: bad entry in file scripts/../../SimplyPianoDroid/scripts/localization/../../ingame/src/com/joytunes/common/localization/Localize.java (line = 43): Argument is not a literal string.

Done

===== Generating localization =====
jtlocalize: ------ genstrings warnings: ------
genstrings: error: bad entry in file scripts/../PianoMoments/PianoMoments/Util/LocalizationUtils.swift (line = 12): Argument is not a literal string.
genstrings: error: bad entry in file scripts/../SimplyPiano/Util/SwiftJTLocalizeUtils.swift (line = 12): Argument is not a literal string.
genstrings: error: bad entry in file scripts/../SimplyPiano/Model/Reminders/RemindersManager.swift (line = 110): Argument is not a literal string.
genstrings: error: bad entry in file scripts/../SimplyPiano/Model/Reminders/RemindersManager.swift (line = 115): Argument is not a literal string.
genstrings: error: bad entry in file scripts/../Pods/AWSMobileAnalytics/AWSMobileAnalytics/Internal/AWSMobileAnalyticsErrorUtils.m (line = 24): Argument is not a literal string.


===== Updating server repo =====
REPO_NAME: server, BRANCH_NAME: master

error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.
WARNING: Pull Failed, proceeding with local copy
Fetching strings from server code

===== Prepare diff =====
Done!
```