### PR TITLE
Use easier format to copy into retained

### DIFF
--- a/JTLocalize.podspec
+++ b/JTLocalize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'JTLocalize'
-  s.version      = '1.0.0'
+  s.version      = '1.1.0'
   s.license      = 'MIT'
   s.homepage     = 'https://github.com/joytunes/JTLocalize'
   s.authors      = { 'JoyTunes' => 'info@joytunes.com' }

--- a/localization_flow/jtlocalize/core/localization_diff.py
+++ b/localization_flow/jtlocalize/core/localization_diff.py
@@ -80,10 +80,10 @@ def localization_diff(localizable_file, translated_file, excluded_strings_file, 
         output_file_elements.append(Comment(u"""
 /*
  * Entry removed from previous translation file:
- * %s
+ * /* %s */
  * "%s" = "%s";
  */
-""" % (", ".join(removed_trans.comments), removed_trans.key, removed_trans.value)))
+""" % (", ".join(removed_trans.comments), removed_trans.key, removed_trans.key)))
 
     write_file_elements_to_strings_file(output_translation_file, output_file_elements)
 

--- a/localization_flow/setup.py
+++ b/localization_flow/setup.py
@@ -4,7 +4,7 @@ import setuptools
 from distutils.core import setup
 
 setup(name='jtlocalize',
-      version='1.0.0',
+      version='1.1.0',
       description='iOS localization framework',
       author='JoyTunes',
       author_email='info@joytunes.com',


### PR DESCRIPTION
After this change, the pending file format would look like this:
```
/**
 * This file contains all the strings that were extracted from our app and that need to be translated.
 * Each entry may or may not have a comment explaining context, and a "key" = "XXX" equation.
 * To localize, you need to fill the right side of the equation with the translation of the left side.
 * Please keep special expressions such as '%@' or '%1$@' as is. Usually the comment will explain their context.
 */

/* Comment for translators */
"String to be translated" = "XXX";

/*
 * Entry removed from previous translation file:
 * /* Achievement text when there is a single unit left */
 * "Collect 1 more star" = "Collect 1 more star";
 */

/*
 * Entry removed from previous translation file:
 * /* Achievement text when there is more than a single unit left */
 * "Play %@ more weeks" = "Play %@ more weeks";
 */
```

Then it should be easier to copy it into the retained file